### PR TITLE
Remove juggler as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "strong-globalize": "^2.6.2"
   },
   "devDependencies": {
-    "loopback-datasource-juggler": "^3.0.0-alpha.8",
     "loopback": "^3.0.0-alpha.5",
     "should": "~9.0.1",
     "mocha": "~2.5.3"


### PR DESCRIPTION
>IMPORTANT: In LoopBack v3.0, loopback-datasource-juggler is no longer a peer dependency that has to be explicitly listed in app/project package.json. Keep this in mind while creating `loopback-2.x` branches and updating `master` to use `loopback@3`.

* Remove juggler as a dependency

/to: @superkhau 
/cc: @bajtos