### PR TITLE
remove listener from correct object

### DIFF
--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -427,7 +427,7 @@ function ready(dataSource, cb) {
   var timeout = dataSource.settings.connectionTimeout || 60000;
   timeoutHandle = setTimeout(function() {
     dataSource.removeListener('error', onError);
-    self.removeListener('connected', onConnected);
+    dataSource.removeListener('connected', onConnected);
     var params = [].slice.call(args);
     var cb = params.pop();
     if (typeof cb === 'function') {


### PR DESCRIPTION
### Description

Self was not defined. The listener was added to `dataSource`.