### PR TITLE
Backport test fixes to loopback 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 node_modules
 !intl/en/
 intl/*
+npm-debug.log
+.vscode
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -11,13 +11,13 @@ var url = require('url');
 var debug = require('debug')('node-soap');
 var VERSION = require('../package.json').version;
 
-var HttpClient = require('soap').HttpClient;
+var HttpClient = require('strong-soap').soap.HttpClient;
 
 function LBHttpClient(options, connector) {
   if (!(this instanceof LBHttpClient)) {
     return new LBHttpClient(options, connector);
   }
-  HttpClient.call(this, options);
+  var httpClient = new HttpClient(this, options);
   this.req = req;
   if (options && options.requestOptions) {
     this.req = req.defaults(options.requestOptions);

--- a/lib/http.js
+++ b/lib/http.js
@@ -8,7 +8,7 @@
 var req = require('request');
 var util = require('util');
 var url = require('url');
-var debug = require('debug')('node-soap');
+var debug = require('debug')('loopback:connector:http');
 var VERSION = require('../package.json').version;
 
 var HttpClient = require('strong-soap').soap.HttpClient;

--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -4,7 +4,7 @@
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 
 var g = require('strong-globalize')();
-var soap = require('soap');
+var soap = require('strong-soap').soap;
 var debug = require('debug')('loopback:connector:soap');
 var HttpClient = require('./http');
 
@@ -135,8 +135,14 @@ SOAPConnector.prototype.connect = function (cb) {
             debug('adding soap header: %j', header);
           }
           if (typeof header === 'object') {
-            client.addSoapHeader(client.wsdl.objectToXML(header.element, header.name,
-              header.prefix, header.namespace, true));
+            var xml = null;
+            for (var item in header.element) {
+              var elementValue = header.element[item];
+              xml = "<"+item+ " xmlns=\""+header.namespace+"\">";
+              xml = xml + elementValue;
+              xml = xml + "</"+item+">"; 
+              client.addSoapHeader(xml);
+            }
           } else if (typeof header === 'string') {
             client.addSoapHeader(header);
           }
@@ -205,12 +211,17 @@ function findKey(obj, val) {
 }
 
 function findMethod(client, name) {
-  var portTypes = client.wsdl.definitions.portTypes;
-  for (var p in portTypes) {
-    var pt = portTypes[p];
-    for (var op in pt.methods) {
-      if (op === name) {
-        return pt.methods[op];
+
+  var services = client.wsdl.services;
+  var service = null;
+  for(var s in services){
+    var service = services[s];
+    for (var p in service.ports) {
+      var pt = service.ports[p];
+      for (var op in pt.binding.operations) {
+        if (op === name) {
+          return pt.binding.operations[op];
+        }
       }
     }
   }
@@ -221,6 +232,11 @@ SOAPConnector.prototype.jsonToXML = function (method, json) {
   if (!json) {
     return '';
   }
+
+  var client = this.client;
+
+  client.describe();
+
   if (typeof method === 'string') {
     var m = findMethod(this.client, method);
     if(!m) {
@@ -229,8 +245,8 @@ SOAPConnector.prototype.jsonToXML = function (method, json) {
       method = m;
     }
   }
-  var client = this.client,
-    name = method.$name,
+
+  var name = method.$name,
     input = method.input,
     defs = client.wsdl.definitions,
     ns = defs.$targetNamespace,
@@ -238,15 +254,17 @@ SOAPConnector.prototype.jsonToXML = function (method, json) {
 
   var alias = findKey(defs.xmlns, ns);
 
-  if (input.parts) {
-    message = client.wsdl.objectToRpcXML(name, json, alias, ns);
+  var inputDecriptor = method.descriptor.input.body;
+
+  if (input.message.parts) {
+    message = client.xmlHandler.jsonToXml(null, null, inputDecriptor, json);
   } else if (typeof json === 'string') {
     message = json;
   } else {
     message = client.wsdl.objectToDocumentXML(input.$name, json,
       input.targetNSAlias, input.targetNamespace, input.$type);
   }
-  return message;
+  return message.toString();
 }
 
 SOAPConnector.prototype.xmlToJSON = function (method, xml) {
@@ -264,13 +282,23 @@ SOAPConnector.prototype.xmlToJSON = function (method, xml) {
   var input = method.input,
     output = method.output;
 
-  var json = this.client.wsdl.xmlToObject(xml);
-  var result = json.Body[output.$name] || json.Body[input.$name];
+  var json = this.client.xmlHandler.xmlToJson(null, xml);
+  var root;
+  var result;
+  if(output.message.parts && output.message.parts.parameters && output.message.parts.parameters.element)
+  {
+    root = output.message.parts.parameters.element.$name;
+    result = json.Body[root];
+  } else if(input.message.parts && input.message.parts.parameters && input.message.parts.parameters.element)
+  {
+    root = input.message.parts.parameters.element.$name;
+    result = json.Body[root];
+  }  
   // RPC/literal response body may contain elements with added suffixes I.E.
   // 'Response', or 'Output', or 'Out'
   // This doesn't necessarily equal the output message name. See WSDL 1.1 Section 2.4.5
   if(!result){
-    result = json.Body[output.$name.replace(/(?:Out(?:put)?|Response)$/, '')];
+    result = json.Body[output.parent.$name.replace(/(?:Out(?:put)?|Response)$/, '')];
   }
   return result;
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "request": "^2.55.0",
-    "soap": "^0.16.0",
+    "strong-soap": "^1.0.1",
     "strong-globalize": "^2.6.2"
   },
   "devDependencies": {

--- a/test/sample-res.json
+++ b/test/sample-res.json
@@ -12,11 +12,11 @@
           "WeatherID": "2",
           "Desciption": "Partly Cloudy",
           "Temperatures": {
-            "MorningLow": null,
+            "MorningLow": "37",
             "DaytimeHigh": "56"
           },
           "ProbabilityOfPrecipiation": {
-            "Nighttime": null,
+            "Nighttime": "00",
             "Daytime": "00"
           }
         },

--- a/test/sample-res.xml
+++ b/test/sample-res.xml
@@ -19,11 +19,11 @@
                         <WeatherID>2</WeatherID>
                         <Desciption>Partly Cloudy</Desciption>
                         <Temperatures>
-                            <MorningLow/>
+                            <MorningLow>37</MorningLow>
                             <DaytimeHigh>56</DaytimeHigh>
                         </Temperatures>
                         <ProbabilityOfPrecipiation>
-                            <Nighttime/>
+                            <Nighttime>00</Nighttime>
                             <Daytime>00</Daytime>
                         </ProbabilityOfPrecipiation>
                     </Forecast>

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -4,7 +4,7 @@
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 
 var fs = require('fs'),
-  soap = require('soap'),
+  soap = require('strong-soap').soap,
   assert = require('assert'),
   loopback = require('loopback'),
   http = require('http');
@@ -18,7 +18,7 @@ test.service = {
         if (args.tickerSymbol === 'trigger error') {
           throw new Error('triggered server error');
         } else {
-          return { price: 19.56 };
+          return {TradePrice: { price: 19.56 }};
         }
       }
     }
@@ -86,7 +86,7 @@ describe('soap connector', function () {
       });
     ds.on('connected', function () {
       var StockQuote = ds.createModel('StockQuote', {});
-      StockQuote.GetLastTradePrice({tickerSymbol: 'IBM'}, function (err, quote) {
+      StockQuote.GetLastTradePrice({TradePriceRequest: {tickerSymbol: 'IBM'}}, function (err, quote) {
         assert.equal(quote.price, '19.56');
         done(err);
       });
@@ -108,7 +108,7 @@ describe('soap connector', function () {
       });
     ds.on('connected', function () {
       var StockQuote = ds.createModel('StockQuote', {});
-      StockQuote.GetLastTradePrice({tickerSymbol: 'IBM'}, function (err, quote) {
+      StockQuote.GetLastTradePrice({TradePriceRequest: {tickerSymbol: 'IBM'}}, function (err, quote) {
         assert(err);
         done();
       });
@@ -159,7 +159,7 @@ describe('soap connector', function () {
       });
     ds.on('connected', function () {
       var StockQuote = ds.createModel('StockQuote', {});
-      StockQuote.GetLastTradePrice({tickerSymbol: 'IBM'}, function (err, quote) {
+      StockQuote.GetLastTradePrice({TradePriceRequest:{tickerSymbol: 'IBM'}}, function (err, quote) {
         assert.equal(quote.price, '19.56');
         done(err);
       });

--- a/test/test.js
+++ b/test/test.js
@@ -86,8 +86,12 @@ describe('soap connector', function () {
 
         // Short method names
         WeatherService.GetCityWeatherByZIP({ZIP: '94555'}, function (err, response) {
-          should.not.exist(err);
-          response.GetCityWeatherByZIPResult.Success.should.be.true;
+          if (!err) {
+            response.GetCityWeatherByZIPResult.Success.should.be.true;
+          } else {
+            //weather external web service server is often down. It's ok to have server 'Internal Server Error' 500 from the server.
+            assert.equal(err.response.statusCode, 500);
+          }
           done();
         });
       });
@@ -252,13 +256,23 @@ describe('soap connector', function () {
 
       it('should invoke the Weather', function(done) {
         WeatherService.cityWeatherByZIP({ZIP: '94555'}, function(err, response) {
-          response.GetCityWeatherByZIPResult.ResponseText.should.equal("City Found")
+          if (!err) {
+            response.GetCityWeatherByZIPResult.ResponseText.should.equal("City Found")
+          } else {
+            //weather external web service is often down. It's ok to have server 'Internal Server Error' 500 from the server
+            assert.equal(err.response.statusCode, 500);
+          }
           done();
         });
       });
       it('should invoke the Weather12', function(done) {
         WeatherService.cityWeatherByZIP12({ZIP: '48206'}, function(err, response) {
-          response.GetCityWeatherByZIPResult.ResponseText.should.equal("City Found")
+          if (!err) {
+            response.GetCityWeatherByZIPResult.ResponseText.should.equal("City Found")
+          } else {
+            //weather external web service is often down. It's ok to have server 'Internal Server Error' 500 from the server
+            assert.equal(err.response.statusCode, 500);
+          }
           done();
         });
       });
@@ -278,7 +292,10 @@ describe('soap connector', function () {
         });
         WeatherService.cityWeatherByZIP({ZIP: '94555'}, function(err, response) {
           assert.deepEqual(events, ['before execute', 'after execute']);
-          done(err, response);
+          if (err) { //weather external web service is often down. It's ok to have server 'Internal Server Error' 500 from the server
+            assert.equal(err.response.statusCode, 500);
+          }
+          done();
         });
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,8 +11,8 @@ var assert = require('assert');
 
 describe('soap connector', function () {
   describe('wsdl configuration', function () {
-    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx down for weeks and until
-    //there is decision on wehther we should use another external web service replacing this.
+    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx is down for weeks and until
+    //there is decision on whether we should use another external web service as a replacement.
     it.skip('should be able to derive wsdl from url', function (done) {
       var ds = loopback.createDataSource('soap',
         {
@@ -39,8 +39,8 @@ describe('soap connector', function () {
       });
     });
 
-    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx down for weeks and until
-    //there is decision on wehther we should use another external web service replacing this.
+    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx is down for weeks and until
+    //there is decision on whether we should use another external web service as a replacement.
     it.skip('should be able to support remote wsdl', function (done) {
       var ds = loopback.createDataSource('soap',
         {
@@ -227,8 +227,8 @@ describe('soap connector', function () {
 
     });
 
-    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx down for weeks and until
-    //there is decision on wehther we should use another external web service replacing this.
+    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx is down for weeks and until
+    //there is decision on whether we should use another external web service as a replacement.
     describe.skip('soap invocations', function() {
       var ds;
       var WeatherService;

--- a/test/test.js
+++ b/test/test.js
@@ -122,16 +122,16 @@ describe('soap connector', function () {
           assert.equal(typeof WeatherService.jsonToXML, 'function');
           assert.equal(typeof WeatherService.GetCityForecastByZIP.jsonToXML, 'function');
           var xml = WeatherService.jsonToXML('GetCityForecastByZIP', JSON.parse(sampleReqJson));
-          assert.equal(xml, '<tns:GetCityForecastByZIP ' +
-            'xmlns:tns="http://ws.cdyne.com/WeatherWS/" ' +
-            'xmlns="http://ws.cdyne.com/WeatherWS/"><tns:ZIP>95131</tns:ZIP>' +
-            '</tns:GetCityForecastByZIP>');
+          assert.equal(xml, '<ns1:GetCityForecastByZIP ' +
+            'xmlns:ns1="http://ws.cdyne.com/WeatherWS/"' +
+            '><ns1:ZIP>95131</ns1:ZIP>' +
+            '</ns1:GetCityForecastByZIP>');
 
           xml = WeatherService.GetCityForecastByZIP.jsonToXML(JSON.parse(sampleReqJson));
-          assert.equal(xml, '<tns:GetCityForecastByZIP ' +
-            'xmlns:tns="http://ws.cdyne.com/WeatherWS/" ' +
-            'xmlns="http://ws.cdyne.com/WeatherWS/"><tns:ZIP>95131</tns:ZIP>' +
-            '</tns:GetCityForecastByZIP>');
+          assert.equal(xml, '<ns1:GetCityForecastByZIP ' +
+            'xmlns:ns1="http://ws.cdyne.com/WeatherWS/"' +
+            '><ns1:ZIP>95131</ns1:ZIP>' +
+            '</ns1:GetCityForecastByZIP>');
         });
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,9 @@ var assert = require('assert');
 
 describe('soap connector', function () {
   describe('wsdl configuration', function () {
-    it('should be able to derive wsdl from url', function (done) {
+    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx down for weeks and until
+    //there is decision on wehther we should use another external web service replacing this.
+    it.skip('should be able to derive wsdl from url', function (done) {
       var ds = loopback.createDataSource('soap',
         {
           connector: require('../index'),
@@ -37,7 +39,9 @@ describe('soap connector', function () {
       });
     });
 
-    it('should be able to support remote wsdl', function (done) {
+    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx down for weeks and until
+    //there is decision on wehther we should use another external web service replacing this.
+    it.skip('should be able to support remote wsdl', function (done) {
       var ds = loopback.createDataSource('soap',
         {
           connector: require('../index'),
@@ -223,7 +227,9 @@ describe('soap connector', function () {
 
     });
 
-    describe('soap invocations', function() {
+    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx down for weeks and until
+    //there is decision on wehther we should use another external web service replacing this.
+    describe.skip('soap invocations', function() {
       var ds;
       var WeatherService;
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,13 +11,12 @@ var assert = require('assert');
 
 describe('soap connector', function () {
   describe('wsdl configuration', function () {
-    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx is down for weeks and until
-    //there is decision on whether we should use another external web service as a replacement.
-    it.skip('should be able to derive wsdl from url', function (done) {
+
+    it('should be able to derive wsdl from url', function (done) {
       var ds = loopback.createDataSource('soap',
         {
           connector: require('../index'),
-          url: 'http://wsf.cdyne.com/WeatherWS/Weather.asmx' // The service endpoint
+          url: 'http://www.webservicex.net/stockquote.asmx' // The service endpoint
         });
       ds.on('connected', function () {
         ds.connector.should.have.property('client');
@@ -39,13 +38,11 @@ describe('soap connector', function () {
       });
     });
 
-    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx is down for weeks and until
-    //there is decision on whether we should use another external web service as a replacement.
-    it.skip('should be able to support remote wsdl', function (done) {
+    it('should be able to support remote wsdl', function (done) {
       var ds = loopback.createDataSource('soap',
         {
           connector: require('../index'),
-          wsdl: 'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL'
+          wsdl: 'http://www.webservicex.net/stockquote.asmx?WSDL'
         });
       ds.on('connected', function () {
         ds.connector.should.have.property('client');
@@ -62,7 +59,7 @@ describe('soap connector', function () {
         ds = loopback.createDataSource('soap',
           {
             connector: require('../index'),
-            wsdl: path.join(__dirname, 'wsdls/weather.wsdl')
+            wsdl: path.join(__dirname, 'wsdls/stockquote_external.wsdl')
           });
         ds.on('connected', function () {
           done();
@@ -70,80 +67,86 @@ describe('soap connector', function () {
       });
 
       it('should create models', function (done) {
-        var WeatherService = ds.createModel('WeatherService', {});
+        var StockQuote = ds.createModel('StockQuoteService', {});
 
         // Short method names
-        (typeof WeatherService.GetCityForecastByZIP).should.eql('function');
-        (typeof WeatherService.GetCityWeatherByZIP).should.eql('function');
-        (typeof WeatherService.GetWeatherInformation).should.eql('function');
-
+        (typeof StockQuote.GetQuote).should.eql('function');
         // Full method names for SOAP 12 operations that conflict with the simple ones
-        (typeof WeatherService.Weather_WeatherSoap12_GetWeatherInformation).should.eql('function');
-        (typeof WeatherService.Weather_WeatherSoap12_GetCityForecastByZIP).should.eql('function');
-        (typeof WeatherService.Weather_WeatherSoap12_GetCityWeatherByZIP).should.eql('function');
+        (typeof StockQuote.StockQuote_StockQuoteSoap12_GetQuote).should.eql('function');
 
         done();
       });
 
       it('should support model methods', function (done) {
-        var WeatherService = ds.createModel('WeatherService', {});
+        var StockQuoteService = ds.createModel('StockQuoteService', {});
 
         // Short method names
-        WeatherService.GetCityWeatherByZIP({ZIP: '94555'}, function (err, response) {
-          if (!err) {
-            response.GetCityWeatherByZIPResult.Success.should.be.true;
-          } else {
-            //weather external web service server is often down. It's ok to have server 'Internal Server Error' 500 from the server.
-            assert.equal(err.response.statusCode, 500);
+        StockQuoteService.GetQuote({symbol: 'IBM'}, function (err, response) {
+          console.log("response: " + response.GetQuoteResult);
+          var index = response.GetQuoteResult.indexOf('<StockQuotes><Stock><Symbol>IBM</Symbol><Last>');
+          //StockQoute external webservice sends 'exception' rarely as a response.  This is not a problem with connector code. This happens even when we use
+          //web service client provided by them, http://www.webservicex.net/New/Home/ServiceDetail/9  Hence below check accounts for this.
+          if (index === -1) {
+            index = response.GetQuoteResult.indexOf('exception');
           }
+          assert.ok(index > -1);
           done();
         });
       });
 
-      describe('XML/JSON conversion utilities', function() {
-        var sampleReq, sampleReqJson, sampleRes, sampleResJson;
+    });
 
-        before(function() {
-          sampleReq = fs.readFileSync(path.join(__dirname, 'sample-req.xml'), 'utf-8');
-          sampleReqJson = fs.readFileSync(path.join(__dirname, 'sample-req.json'), 'utf-8');
-          sampleRes = fs.readFileSync(path.join(__dirname, 'sample-res.xml'), 'utf-8');
-          sampleResJson = fs.readFileSync(path.join(__dirname, 'sample-res.json'), 'utf-8');
-        });
-
-        it('should support xmlToJSON methods', function () {
-          var WeatherService = ds.createModel('WeatherService', {});
-          assert.equal(typeof WeatherService.xmlToJSON, 'function');
-          assert.equal(typeof WeatherService.GetCityForecastByZIP.xmlToJSON, 'function');
-
-          var json = WeatherService.xmlToJSON('GetCityForecastByZIP', sampleReq);
-          assert.deepEqual(json, JSON.parse(sampleReqJson));
-
-          json = WeatherService.GetCityForecastByZIP.xmlToJSON(sampleReq);
-          assert.deepEqual(json, JSON.parse(sampleReqJson));
-
-          json = WeatherService.GetCityForecastByZIP.xmlToJSON(sampleRes);
-          assert.deepEqual(json, JSON.parse(sampleResJson));
-        });
-
-        it('should support jsonToXML methods', function () {
-          var WeatherService = ds.createModel('WeatherService', {});
-          assert.equal(typeof WeatherService.jsonToXML, 'function');
-          assert.equal(typeof WeatherService.GetCityForecastByZIP.jsonToXML, 'function');
-          var xml = WeatherService.jsonToXML('GetCityForecastByZIP', JSON.parse(sampleReqJson));
-          assert.equal(xml, '<ns1:GetCityForecastByZIP ' +
-            'xmlns:ns1="http://ws.cdyne.com/WeatherWS/"' +
-            '><ns1:ZIP>95131</ns1:ZIP>' +
-            '</ns1:GetCityForecastByZIP>');
-
-          xml = WeatherService.GetCityForecastByZIP.jsonToXML(JSON.parse(sampleReqJson));
-          assert.equal(xml, '<ns1:GetCityForecastByZIP ' +
-            'xmlns:ns1="http://ws.cdyne.com/WeatherWS/"' +
-            '><ns1:ZIP>95131</ns1:ZIP>' +
-            '</ns1:GetCityForecastByZIP>');
+    describe('XML/JSON conversion utilities', function() {
+      var ds;
+      before(function (done) {
+        sampleReq = fs.readFileSync(path.join(__dirname, 'sample-req.xml'), 'utf-8');
+        sampleReqJson = fs.readFileSync(path.join(__dirname, 'sample-req.json'), 'utf-8');
+        sampleRes = fs.readFileSync(path.join(__dirname, 'sample-res.xml'), 'utf-8');
+        sampleResJson = fs.readFileSync(path.join(__dirname, 'sample-res.json'), 'utf-8');
+        ds = loopback.createDataSource('soap',
+            {
+              connector: require('../index'),
+              wsdl: path.join(__dirname, 'wsdls/weather.wsdl')
+            });
+        ds.on('connected', function () {
+          done();
         });
       });
+      var sampleReq, sampleReqJson, sampleRes, sampleResJson;
 
+      it('should support xmlToJSON methods', function () {
+        var WeatherService = ds.createModel('WeatherService', {});
+        assert.equal(typeof WeatherService.xmlToJSON, 'function');
+        assert.equal(typeof WeatherService.GetCityForecastByZIP.xmlToJSON, 'function');
+
+        var json = WeatherService.xmlToJSON('GetCityForecastByZIP', sampleReq);
+        assert.deepEqual(json, JSON.parse(sampleReqJson));
+
+        json = WeatherService.GetCityForecastByZIP.xmlToJSON(sampleReq);
+        assert.deepEqual(json, JSON.parse(sampleReqJson));
+
+        json = WeatherService.GetCityForecastByZIP.xmlToJSON(sampleRes);
+        assert.deepEqual(json, JSON.parse(sampleResJson));
+      });
+
+      it('should support jsonToXML methods', function () {
+        var WeatherService = ds.createModel('WeatherService', {});
+        assert.equal(typeof WeatherService.jsonToXML, 'function');
+        assert.equal(typeof WeatherService.GetCityForecastByZIP.jsonToXML, 'function');
+        var xml = WeatherService.jsonToXML('GetCityForecastByZIP', JSON.parse(sampleReqJson));
+        assert.equal(xml, '<ns1:GetCityForecastByZIP ' +
+            'xmlns:ns1="http://ws.cdyne.com/WeatherWS/"' +
+            '><ns1:ZIP>95131</ns1:ZIP>' +
+            '</ns1:GetCityForecastByZIP>');
+
+        xml = WeatherService.GetCityForecastByZIP.jsonToXML(JSON.parse(sampleReqJson));
+        assert.equal(xml, '<ns1:GetCityForecastByZIP ' +
+            'xmlns:ns1="http://ws.cdyne.com/WeatherWS/"' +
+            '><ns1:ZIP>95131</ns1:ZIP>' +
+            '</ns1:GetCityForecastByZIP>');
+      });
     });
+
 
     describe('models with remotingEnabled', function () {
       var ds;
@@ -227,58 +230,63 @@ describe('soap connector', function () {
 
     });
 
-    //skipping the test since external web service http://wsf.cdyne.com/WeatherWS/Weather.asmx is down for weeks and until
-    //there is decision on whether we should use another external web service as a replacement.
-    describe.skip('soap invocations', function() {
+
+    describe('soap invocations', function() {
       var ds;
-      var WeatherService;
+      var StockQuoteService;
 
       before(function(done) {
         ds = loopback.createDataSource('soap',
           {
             connector: require('../index'),
-            wsdl: 'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL', // The url to WSDL
-            url: 'http://wsf.cdyne.com/WeatherWS/Weather.asmx', // The service endpoint
+            wsdl: 'http://www.webservicex.net/stockquote.asmx?WSDL', // The url to WSDL
+            url: 'http://www.webservicex.net/stockquote.asmx', // The service endpoint
             // Map SOAP service/port/operation to Node.js methods
             operations: {
               // The key is the method name
-              cityWeatherByZIP: {
-                service: 'Weather', // The WSDL service name
-                port: 'WeatherSoap', // The WSDL port name
-                operation: 'GetCityWeatherByZIP' // The WSDL operation name
+              getQuote: {
+                service: 'StockQuote', // The WSDL service name
+                port: 'StockQuoteSoap', // The WSDL port name
+                operation: 'GetQuote' // The WSDL operation name
               },
-              cityWeatherByZIP12: {
-                service: 'Weather', // The WSDL service name
-                port: 'WeatherSoap12', // The WSDL port name
-                operation: 'GetCityWeatherByZIP' // The WSDL operation name
+              getQuote12: {
+                service: 'StockQuote', // The WSDL service name
+                port: 'StockQuoteSoap12', // The WSDL port name
+                operation: 'GetQuote' // The WSDL operation name
               }
             }
           });
         ds.on('connected', function() {
-          WeatherService = ds.createModel('WeatherService',{});
+          StockQuote = ds.createModel('StockQuoteService',{});
           done();
         });
       });
 
-      it('should invoke the Weather', function(done) {
-        WeatherService.cityWeatherByZIP({ZIP: '94555'}, function(err, response) {
-          if (!err) {
-            response.GetCityWeatherByZIPResult.ResponseText.should.equal("City Found")
-          } else {
-            //weather external web service is often down. It's ok to have server 'Internal Server Error' 500 from the server
-            assert.equal(err.response.statusCode, 500);
+      it('should invoke the getQuote', function(done) {
+        StockQuote.getQuote({symbol: 'IBM'}, function(err, response) {
+          //check  server response - can't check for stock price since it varies, just check for first part of the response
+          var index = response.GetQuoteResult.indexOf('<StockQuotes><Stock><Symbol>IBM</Symbol><Last>');
+          console.log("response: " + response.GetQuoteResult);
+          //StockQoute external webservice sends 'exception' rarely as a response. This is not a problem with connector code. This happens even when we use web
+          //service client provided by them, http://www.webservicex.net/New/Home/ServiceDetail/9  Hence below check accounts for this.
+          if (index === -1) {
+            index = response.GetQuoteResult.indexOf('exception');
           }
+          assert.ok(index > -1);
           done();
         });
       });
-      it('should invoke the Weather12', function(done) {
-        WeatherService.cityWeatherByZIP12({ZIP: '48206'}, function(err, response) {
-          if (!err) {
-            response.GetCityWeatherByZIPResult.ResponseText.should.equal("City Found")
-          } else {
-            //weather external web service is often down. It's ok to have server 'Internal Server Error' 500 from the server
-            assert.equal(err.response.statusCode, 500);
+      it('should invoke the getQuote12', function(done) {
+        StockQuote.getQuote12({symbol: 'IBM'}, function(err, response) {
+          console.log("response: " + response.GetQuoteResult);
+          //check  server response - can't check for stock price since it varies, just check for first part of the response
+          var index = response.GetQuoteResult.indexOf('<StockQuotes><Stock><Symbol>IBM</Symbol><Last>');
+          //StockQoute external webservice sends 'exception' rarely as a response. This is not a problem with connector code. This happens even when we use web service
+          //client provided by them, http://www.webservicex.net/New/Home/ServiceDetail/9  Hence below check accounts for this.
+          if (index === -1) {
+            index = response.GetQuoteResult.indexOf('exception');
           }
+          assert.ok(index > -1);
           done();
         });
       });
@@ -296,11 +304,8 @@ describe('soap connector', function () {
           events.push('after execute');
           next();
         });
-        WeatherService.cityWeatherByZIP({ZIP: '94555'}, function(err, response) {
+        StockQuote.getQuote({symbol: 'IBM'}, function(err, response) {
           assert.deepEqual(events, ['before execute', 'after execute']);
-          if (err) { //weather external web service is often down. It's ok to have server 'Internal Server Error' 500 from the server
-            assert.equal(err.response.statusCode, 500);
-          }
           done();
         });
       });

--- a/test/wsdls/stockquote_external.wsdl
+++ b/test/wsdls/stockquote_external.wsdl
@@ -1,0 +1,122 @@
+<wsdl:definitions xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://www.webserviceX.NET/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://www.webserviceX.NET/">
+    <wsdl:types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://www.webserviceX.NET/">
+            <s:element name="GetQuote">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="symbol" type="s:string"/>
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetQuoteResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetQuoteResult" type="s:string"/>
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="string" nillable="true" type="s:string"/>
+        </s:schema>
+    </wsdl:types>
+    <wsdl:message name="GetQuoteSoapIn">
+        <wsdl:part name="parameters" element="tns:GetQuote"/>
+    </wsdl:message>
+    <wsdl:message name="GetQuoteSoapOut">
+        <wsdl:part name="parameters" element="tns:GetQuoteResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetQuoteHttpGetIn">
+        <wsdl:part name="symbol" type="s:string"/>
+    </wsdl:message>
+    <wsdl:message name="GetQuoteHttpGetOut">
+        <wsdl:part name="Body" element="tns:string"/>
+    </wsdl:message>
+    <wsdl:message name="GetQuoteHttpPostIn">
+        <wsdl:part name="symbol" type="s:string"/>
+    </wsdl:message>
+    <wsdl:message name="GetQuoteHttpPostOut">
+        <wsdl:part name="Body" element="tns:string"/>
+    </wsdl:message>
+    <wsdl:portType name="StockQuoteSoap">
+        <wsdl:operation name="GetQuote">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get Stock quote for a company Symbol</wsdl:documentation>
+            <wsdl:input message="tns:GetQuoteSoapIn"/>
+            <wsdl:output message="tns:GetQuoteSoapOut"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:portType name="StockQuoteHttpGet">
+        <wsdl:operation name="GetQuote">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get Stock quote for a company Symbol</wsdl:documentation>
+            <wsdl:input message="tns:GetQuoteHttpGetIn"/>
+            <wsdl:output message="tns:GetQuoteHttpGetOut"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:portType name="StockQuoteHttpPost">
+        <wsdl:operation name="GetQuote">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get Stock quote for a company Symbol</wsdl:documentation>
+            <wsdl:input message="tns:GetQuoteHttpPostIn"/>
+            <wsdl:output message="tns:GetQuoteHttpPostOut"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="StockQuoteSoap" type="tns:StockQuoteSoap">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="GetQuote">
+            <soap:operation soapAction="http://www.webserviceX.NET/GetQuote" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="StockQuoteSoap12" type="tns:StockQuoteSoap">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="GetQuote">
+            <soap12:operation soapAction="http://www.webserviceX.NET/GetQuote" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="StockQuoteHttpGet" type="tns:StockQuoteHttpGet">
+        <http:binding verb="GET"/>
+        <wsdl:operation name="GetQuote">
+            <http:operation location="/GetQuote"/>
+            <wsdl:input>
+                <http:urlEncoded/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="StockQuoteHttpPost" type="tns:StockQuoteHttpPost">
+        <http:binding verb="POST"/>
+        <wsdl:operation name="GetQuote">
+            <http:operation location="/GetQuote"/>
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="StockQuote">
+        <wsdl:port name="StockQuoteSoap" binding="tns:StockQuoteSoap">
+            <soap:address location="http://www.webservicex.net/stockquote.asmx"/>
+        </wsdl:port>
+        <wsdl:port name="StockQuoteSoap12" binding="tns:StockQuoteSoap12">
+            <soap12:address location="http://www.webservicex.net/stockquote.asmx"/>
+        </wsdl:port>
+        <wsdl:port name="StockQuoteHttpGet" binding="tns:StockQuoteHttpGet">
+            <http:address location="http://www.webservicex.net/stockquote.asmx"/>
+        </wsdl:port>
+        <wsdl:port name="StockQuoteHttpPost" binding="tns:StockQuoteHttpPost">
+            <http:address location="http://www.webservicex.net/stockquote.asmx"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Cherry-pick of all the commits on `master` related to `test/` that weren't part of the `loopback-2.x` branch (ex. `git log origin/master  --not origin/loopback-2.x  -- test`).

This is a blind backport, all I did was cherry-pick the commits and verify that `npm test` passes locally. I don't know if _all_ of the changes actually make sense or not since I haven't looked at them in detail.