### PR TITLE
TypeError: Cannot read property 'pfx' of null

### DIFF
--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -96,7 +96,7 @@ SOAPConnector.prototype.connect = function (cb) {
             );
             break;
           case 'ClientSSL':
-            if (sec.pfx) {
+            if (secConfig.pfx) {
               sec = new soap.ClientSSLSecurityPFX(
                 secConfig.pfx,
                 secConfig.passphrase,


### PR DESCRIPTION
TypeError: Cannot read property 'pfx' of null

https://github.com/strongloop/loopback-connector-soap/issues/85
I am not return any unit test cases about please review and merge the code.