### PR TITLE
fix client SSL pfx

### DIFF
--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -96,7 +96,7 @@ SOAPConnector.prototype.connect = function (cb) {
             );
             break;
           case 'ClientSSL':
-            if (sec.pfx) {
+            if (secConfig.pfx) {
               sec = new soap.ClientSSLSecurityPFX(
                 secConfig.pfx,
                 secConfig.passphrase,


### PR DESCRIPTION
I have fixed the TypeError: Cannot read property 'pfx' of null https://github.com/strongloop/loopback-connector-soap/issues/85 but I am not added any unit test case. please merge the code