### PR TITLE
Add test case for operations returning promise

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -94,6 +94,22 @@ describe('soap connector', function () {
         });
       });
 
+      it('should support model methods as promises', function (done) {
+        var StockQuoteService = ds.createModel('StockQuoteService', {});
+
+        // Short method names
+        StockQuoteService.GetQuote({symbol: 'IBM'}).then(function (response) {
+          var index = response.GetQuoteResult.indexOf('<StockQuotes><Stock><Symbol>IBM</Symbol><Last>');
+          //StockQoute external webservice sends 'exception' rarely as a response.  This is not a problem with connector code. This happens even when we use
+          //web service client provided by them, http://www.webservicex.net/New/Home/ServiceDetail/9  Hence below check accounts for this.
+          if (index === -1) {
+            index = response.GetQuoteResult.indexOf('exception');
+          }
+          assert.ok(index > -1);
+          done();
+        }, done);
+      });
+
     });
 
     describe('XML/JSON conversion utilities', function() {


### PR DESCRIPTION
### Description
NOTE: the added test case will fail since the endpoint it's testing for is down. Considering that the error is thrown properly with `done`, one may say that the test fulfills its intended purpose despite it failing 😅
- Fixes https://github.com/strongloop/loopback-next/issues/1272

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
