### PR TITLE
[WIP] Allow SOAP methods to be invoked before the datasource is connected

### DIFF
--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -324,16 +324,29 @@ SOAPConnector.prototype.setupDataAccessObject = function () {
     for (var p in service) {
       var port = service[p];
       for (var m in port) {
-        var method = port[m];
+        let method = port[m];
         if (debug.enabled) {
           debug('Adding method: %s %s %s', s, p, m);
         }
 
-        var methodName = this._methodName(s, p, m, this.DataAccessObject);
+        let methodName = this._methodName(s, p, m, this.DataAccessObject);
         if (debug.enabled) {
           debug('Method name: %s', methodName);
         }
-        var wsMethod = method.bind(this.client);
+        let wsMethod = method.bind(this.client);
+        wsMethod = (...args) => {
+          let cb;
+          let isAPromise = args.every(arg => typeof arg !== 'function');
+          if (isAPromise) {
+            cb = createPromiseCallback();
+          }
+          ready(this.dataSource, () => {
+            method(...args, cb);
+          });
+          if (cb) {
+            return cb.promise;
+          }
+        };
 
         wsMethod.jsonToXML = SOAPConnector.prototype.jsonToXML.bind(self, findMethod(self.client, m));
         wsMethod.xmlToJSON = SOAPConnector.prototype.xmlToJSON.bind(self, findMethod(self.client, m));
@@ -425,6 +438,7 @@ function ready(dataSource, cb) {
 
   // Set up a timeout to cancel the invocation
   var timeout = dataSource.settings.connectionTimeout || 60000;
+  console.log(dataSource.settings);
   timeoutHandle = setTimeout(function() {
     dataSource.removeListener('error', onError);
     self.removeListener('connected', onConnected);
@@ -438,6 +452,21 @@ function ready(dataSource, cb) {
   if (!dataSource.connecting) {
     dataSource.connect();
   }
+}
+
+function createPromiseCallback() {
+  var cb;
+  var promise = new Promise(function(resolve, reject) {
+    cb = function(err, result, envelope, soapHeader) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({result, envelope, soapHeader});
+      }
+    }
+  });
+  cb.promise = promise;
+  return cb;
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -181,6 +181,93 @@ describe('soap connector', function () {
       });
     });
 
+    describe('without listener on "connected"', function () {
+      var ds;
+      var EmailvernotestemailService;
+
+      before(function () {
+        ds = loopback.createDataSource('soap',
+          {
+            connector: require('../index'),
+            wsdl: 'http://ws.cdyne.com/emailverify/Emailvernotestemail.asmx?wsdl', // The url to WSDL
+            url: 'http://ws.cdyne.com/emailverify/Emailvernotestemail.asmx', // The service endpoint
+            // Map SOAP service/port/operation to Node.js methods
+            operations: {
+              // The key is the method name
+              verifyMXRecord: {
+                service: 'EmailVerNoTestEmail', // The WSDL service name
+                port: 'EmailVerNoTestEmailSoap', // The WSDL port name
+                operation: 'VerifyMXRecord' // The WSDL operation name
+              },
+              verifyMXRecord2: {
+                service: 'EmailVerNoTestEmail', // The WSDL service name
+                port: 'EmailVerNoTestEmailSoap12', // The WSDL port name
+                operation: 'VerifyMXRecord' // The WSDL operation name
+              }
+            }
+          });
+      });
+
+      it('should invoke the verifyMXRecord', function (done) {
+        EmailvernotestemailService = ds.createModel('EmailvernotestemailService', {});
+        EmailvernotestemailService.verifyMXRecord({
+          email: 'test@email.com',
+          LicenseKey: 0
+        }, function (err, response) {
+          if (err) {
+            err.should.match(/Timeout in connecting/);
+            done();
+          }
+          assert.ok(typeof response.VerifyMXRecordResult === 'number');
+          return done();
+        });
+      });
+    })
+
+    describe('on stuck datasource', function () {
+      var ds;
+      var EmailvernotestemailService;
+
+      before(function () {
+        ds = loopback.createDataSource('soap',
+          {
+            connector: require('../index'),
+            wsdl: 'http://ws.cdyne.com/emailverify/Emailvernotestemail.asmx?wsdl', // The url to WSDL
+            url: 'http://ws.cdyne.com/emailverify/Emailvernotestemail.asmx', // The service endpoint
+            // Map SOAP service/port/operation to Node.js methods
+            operations: {
+              // The key is the method name
+              verifyMXRecord: {
+                service: 'EmailVerNoTestEmail', // The WSDL service name
+                port: 'EmailVerNoTestEmailSoap', // The WSDL port name
+                operation: 'VerifyMXRecord' // The WSDL operation name
+              },
+              verifyMXRecord2: {
+                service: 'EmailVerNoTestEmail', // The WSDL service name
+                port: 'EmailVerNoTestEmailSoap12', // The WSDL port name
+                operation: 'VerifyMXRecord' // The WSDL operation name
+              }
+            }
+          });
+      });
+
+      it('should invoke the verifyMXRecord', function (done) {
+        EmailvernotestemailService = ds.createModel('EmailvernotestemailService', {});
+        ds.on('connected', () => {
+          ds.connected = false;
+        })
+        EmailvernotestemailService.verifyMXRecord({
+          email: 'test@email.com',
+          LicenseKey: 0
+        }, function (err, response) {
+          console.log(response);
+          console.log(err);
+          err.should.match(/Timeout in connecting/);
+          done();
+        });
+      });
+    })
+
     describe('models with operations', function () {
       var ds;
       before(function (done) {


### PR DESCRIPTION
### Description
This PR would allow users to call the methods on their SOAP services without putting it behind a listener. This is done by explicitly checking if the datasource is connected before the method is invoked, similar to how it is done in the juggler. See https://github.com/strongloop/loopback-datasource-juggler/blob/4d14c1473fe5a670369553a1969efffe8b05c71a/lib/dao.js#L1336-L1339

- related to strongloop/loopback-next#1553

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
