### PR TITLE
feat: Add ability to pass json soapHeader

### DIFF
--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -15,7 +15,6 @@ var HttpClient = require('./http');
  */
 exports.initialize = function initializeDataSource(dataSource, callback) {
   var settings = dataSource.settings || {};
-
   var connector = new SOAPConnector(settings);
 
   dataSource.connector = connector;
@@ -147,6 +146,10 @@ SOAPConnector.prototype.connect = function (cb) {
             client.addSoapHeader(header);
           }
         });
+      } else {
+        if (self.settings.soapHeaders) { 
+          client.addSoapHeader(self.settings.soapHeaders)
+        }
       }
 
       client.connector = self;


### PR DESCRIPTION
### Description
This PR add the ability to accept a JSON object in the header and then sent thru the soapHeader method of the client, making more easy to understand by developers that are more used to JSON terminology.

We are connecting to a set of  Bank Web Services that require an authentication tag in the header, it doesn't work with any other type of authentication (Basic, WS, etc.).  It expects the following in the heder.

```
<authentication><username>xxx</username><password>xx</password></authentication>
```
We could send this using datasource JSON configuration as follows:

```
"soapHeaders": [{
       "element": {"authentication":"<userName>xxxx</userName><password>xxx</password>"}
  }]
```
But with this PR we can easily (without having to worry about the XML meta tags), the following:

```
"soapHeaders": {"authentication": {"userName": "xx", "password": "xx"}},
```
 
### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
