### PR TITLE
Update to MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,25 @@
-Licensed Materials - Property of IBM
-IBM StrongLoop Software
-Copyright IBM Corp. 2016. All Rights Reserved.
-US Government Users Restricted Rights - Use, duplication or disclosure
-restricted by GSA ADP Schedule Contract with IBM Corp.
+Copyright (c) IBM Corp. 2012,2018. All Rights Reserved.
+Node module: loopback-connector-soap
+This project is licensed under the MIT License, full text below.
 
-See full text of IBM International Program License Agreement (IPLA)
-http://www-03.ibm.com/software/sla/sladb.nsf/pdf/ipla/$file/ipla.pdf
+--------
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,7 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-soap
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
-
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 
 var SG = require('strong-globalize');
 SG.SetRootDir(__dirname); 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
 // Node module: loopback-connector-soap
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,10 +1,7 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-soap
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
-
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 
 'use strict';
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2015. All Rights Reserved.
+// Copyright IBM Corp. 2015,2016. All Rights Reserved.
 // Node module: loopback-connector-soap
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2015. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-soap
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/lib/soap-connector.js
+++ b/lib/soap-connector.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 var g = require('strong-globalize')();
 var soap = require('strong-soap').soap;
 var debug = require('debug')('loopback:connector:soap');

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/strongloop/loopback-connector-soap.git"
-  },
-  "license": "SEE LICENSE IN LICENSE.md"
+  },  
+  "copyright.owner": "IBM Corp.",
+  "license": "MIT"
 }

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,10 +1,7 @@
-// Copyright IBM Corp. 2014,2017. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-soap
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
-
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 
 var fs = require('fs'),
   soap = require('strong-soap').soap,

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2014. All Rights Reserved.
+// Copyright IBM Corp. 2014,2017. All Rights Reserved.
 // Node module: loopback-connector-soap
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 var should = require('should');

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2014,2015. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-soap
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 


### PR DESCRIPTION
### Description
To help to continue growing the community, we decided to change the license of this module to MIT license.

The license used here is using https://github.com/strongloop/loopback-connector-mysql/blob/master/LICENSE as reference.

Changes involved in this PR:

- update `LICENSE.md` to MIT license
- update `license` and `copyright.owner` field, in package.json
- run `slt copyright` to update the copyright statement in the header of source code files.